### PR TITLE
Fix crash on IE11 when previouslyFocused is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function deactivate() {
   if (config.onDeactivate) config.onDeactivate();
 
   setTimeout(function() {
-    if ( previouslyFocused ) {
+    if ( previouslyFocused && previouslyFocused.focus ) {
       previouslyFocused.focus();  
     }
   }, 0);

--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ function deactivate() {
   if (config.onDeactivate) config.onDeactivate();
 
   setTimeout(function() {
-    previouslyFocused.focus();
+    if ( previouslyFocused ) {
+      previouslyFocused.focus();  
+    }
   }, 0);
 }
 


### PR DESCRIPTION
I was seeing this happen on IE11 on various versions of Windows.