### PR TITLE
add support for nonModal option; fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,12 @@ function deactivate() {
 
 function checkClick(e) {
   if (trap.contains(e.target)) return;
+
+  if (config.nonModal) {
+    deactivate();
+    return;
+  }
+
   e.preventDefault();
   e.stopImmediatePropagation();
 }


### PR DESCRIPTION
This adds a `nonModal` option to the config object, allowing the focus trap to be deactivated on clicks outside of the trap element ([issue #4](https://github.com/davidtheclark/focus-trap/issues/4)).