### PR TITLE
Added an option for delaying the initial focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Returns a new focus trap on `element`.
 - **onActivate** {function}: A function that will be called when the focus trap activates.
 - **onDeactivate** {function}: A function that will be called when the focus trap deactivates,
 - **initialFocus** {element|string}: By default, when a focus trap is activated the first element in the focus trap's tab order will receive focus. With this option you can specify a different element to receive that initial focus. Can be a DOM node or a selector string (which will be passed to `document.querySelector()` to find the DOM node).
+- **initialFocusDelay** {number}: An option to delay the initial focus. Can come in handy if there is an animation in progress of the DOM container which contains the elements that can be focused.
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
 - ** returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function focusTrap(element, userOptions) {
     listeningFocusTrap = trap;
 
     updateTabbableNodes();
-    tryFocus(firstFocusNode());
+    initialFocus()
     document.addEventListener('focus', checkFocus, true);
     document.addEventListener('click', checkClick, true);
     document.addEventListener('mousedown', checkPointerDown, true);
@@ -90,6 +90,16 @@ function focusTrap(element, userOptions) {
     document.addEventListener('keydown', checkKey, true);
 
     return trap;
+  }
+
+  function initialFocus() {
+    if (config.initialFocusDelay) {
+      setTimeout(function() {
+        tryFocus(firstFocusNode())
+      }, config.initialFocusDelay)
+    } else {
+      tryFocus(firstFocusNode())
+    }
   }
 
   function removeListeners() {


### PR DESCRIPTION
I have currently ran into a situation where if there is an animation in progress, voiceover on iOS acts pretty flaky and manages to focus on an focusable element at times, and not at times. Letting the animation finish and then proceeding with the focus seems to solve the problem.