### PR TITLE
Do not throw Error if no focusable Element is available

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function focusTrap(element, userOptions) {
     if (!config.initialFocus) {
       node = tabbableNodes[0];
       if (!node) {
-        throw new Error('You can\'t have a focus-trap without at least one focusable element');
+        return null;
       }
       return node;
     }


### PR DESCRIPTION
This change prevents `focus-trap` from failing because of a missing focusable element within its target element.

### Use Case
This change comes handy when using `focus-trap-react`: I had the specific situation where i wrap the `FocusTrap` around my generic modal dialog.
The dialogs content itself does not have focusable elements right from the start: First, there is only a loading text. The "real", focusable, content follows a split second later.

### Risks?
Digging into the code of `focus-trap` revealed that `tryFocus` was already robust enough to handle a `null`-return from `firstFocusNode`. Replacing line `115` with a simple `return null;` should not be dangerous at all then.

### Future Ideas
There could be a warning instead of a more strict error in the future. What kind of mechanism would you prefer to turn it off in production mode?

Suggestion: `process.env.NODE_ENV`?

### Kudos
Thank you for your module! `focus-trap` and `focus-trap-react` saved me a lot of implementation headache ☺️