### PR TITLE
Fix Outside Detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function focusTrap(element, userOptions) {
   // This needs to be done on mousedown and touchstart instead of click
   // so that it precedes the focus event
   function checkPointerDown(e) {
-    if (config.clickOutsideDeactivates) {
+    if (config.clickOutsideDeactivates && !container.contains(e.target)) {
       deactivate({ returnFocus: false });
     }
   }


### PR DESCRIPTION
This change fixes the functionality which detects pointer events
outside of the focus trap.

Before, ANY pointer event, even inside of the focus trap, deactivated
it. By using the containers contain function with the events target,
this problem was fixed.