### PR TITLE
fix condition in removeListeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function focusTrap(element, userOptions) {
   }
 
   function removeListeners() {
-    if (!active || !listeningFocusTrap) return;
+    if (!active || listeningFocusTrap !== trap) return;
 
     document.removeEventListener('focus', checkFocus, true);
     document.removeEventListener('click', checkClick, true);


### PR DESCRIPTION
Problem that this pull is solving.

1) You have one trap that is paused, not deactivated, and then you have another which is listening.
2) When you call deactivate (or pause) on first one, it passes current condition (since it is still active, even though it is paused, and there is listeningFocusTrap) and set listeningFocusTrap to null.
3) When you then call deactivate (or pause) on the second trap (which is listening), it doesn't pass condition, because, even though it is really listening, listeningFocusTrap was set to null in step 2. So you end up in situation where you can't remove listeners of this trap.

Problem lies in condition that allows paused trap to set listeningFocusTrap to null.