### PR TITLE
Add fallbackFocus option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Returns a new focus trap on `element`.
 - **onActivate** {function}: A function that will be called when the focus trap activates.
 - **onDeactivate** {function}: A function that will be called when the focus trap deactivates,
 - **initialFocus** {element|string}: By default, when a focus trap is activated the first element in the focus trap's tab order will receive focus. With this option you can specify a different element to receive that initial focus. Can be a DOM node or a selector string (which will be passed to `document.querySelector()` to find the DOM node).
+- **fallbackFocus** {element|string}: By default, an error will be thrown if the focus trap contains no elements in its tab order. With this option you can specify a fallback element to programmatically receive focus if no other tabbable elements are found. For example, you may want a popover's `<div>` to receive focus if the popover's content includes no tabbable elements. *Make sure the fallback element has a negative `tabindex` so it can be programmatically focused.* The option value can be a DOM node or a selector string (which will be passed to `document.querySelector()` to find the DOM node).
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
-- ** returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
+- **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
 
 ### focusTrap.activate()
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -213,6 +213,32 @@
     </div>
   </div>
 
+  <h2 id="demo-seven-heading">demo seven</h2>
+  <p>
+  </p>
+  <p>
+    <button id="activate-seven">
+      activate trap 7
+    </button>
+  </p>
+  <div id="demo-seven" class="trap" tabindex="-1">
+    <p>
+      <button id="deactivate-seven" tabindex="-1">
+        deactivate trap 7
+      </button>
+    </p>
+    <p>
+      <button id="demo-seven-show-focusable" tabindex="-1">
+        show focusable button
+      </button>
+    </p>
+    <p>
+      <button id="demo-seven-hide-focusable" style="display:none;">
+        hide focusable button
+      </button>
+    </p>
+  </div>
+
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/davidtheclark/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/index.html
+++ b/demo/index.html
@@ -215,6 +215,9 @@
 
   <h2 id="demo-seven-heading">demo seven</h2>
   <p>
+    In this focus traps, the single focusable button are hidden.
+    If you activate the trap in this state, the "fallbackFocus" option is used to focus the container.
+    If, however, you make the focusable button visible, it will receive focus when you activate the trap.
   </p>
   <p>
     <button id="activate-seven">

--- a/demo/js/demo-seven.js
+++ b/demo/js/demo-seven.js
@@ -1,0 +1,32 @@
+var createFocusTrap = require('../../');
+
+var containerSeven = document.getElementById('demo-seven');
+var focusableSeven = document.getElementById('demo-seven-hide-focusable');
+
+var focusTrapSeven = createFocusTrap(containerSeven, {
+  fallbackFocus: containerSeven,
+  onActivate: function() {
+    containerSeven.className = 'trap is-active';
+  },
+  onDeactivate: function() {
+    containerSeven.className = 'trap';
+  },
+});
+
+document.getElementById('activate-seven').addEventListener('click', function() {
+  focusTrapSeven.activate();
+});
+
+document.getElementById('deactivate-seven').addEventListener('click', function() {
+  focusTrapSeven.deactivate();
+});
+
+document.getElementById('demo-seven-show-focusable').addEventListener('click', function() {
+  focusableSeven.style.display = 'block';
+});
+
+document.getElementById('demo-seven-hide-focusable').addEventListener('click', function() {
+  focusableSeven.style.display = 'none';
+});
+
+console.log('here')

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -4,3 +4,4 @@ require('./demo-three');
 require('./demo-four');
 require('./demo-five');
 require('./demo-six');
+require('./demo-seven');

--- a/index.js
+++ b/index.js
@@ -106,22 +106,25 @@ function focusTrap(element, userOptions) {
     return trap;
   }
 
-  function firstFocusNode() {
-    var node;
-
-    if (!config.initialFocus) {
-      node = tabbableNodes[0];
-      if (!node) {
-        throw new Error('You can\'t have a focus-trap without at least one focusable element');
-      }
-      return node;
-    }
-
-    node = (typeof config.initialFocus === 'string')
-      ? document.querySelector(config.initialFocus)
-      : config.initialFocus;
+  function getNodeForOption(key) {
+    var node = config[key];
     if (!node) {
-      throw new Error('`initialFocus` refers to no known node');
+      return null;
+    }
+    if (typeof node === 'string') {
+      node = document.querySelector(node);
+      if (!node) {
+        throw new Error('`'+key+'` refers to no known node');
+      }
+    }
+    return node;
+  }
+
+  function firstFocusNode() {
+    var node = getNodeForOption('initialFocus') || tabbableNodes[0] || getNodeForOption('fallbackFocus');
+
+    if (!node) {
+      throw new Error('You can\'t have a focus-trap without at least one focusable element');
     }
 
     return node;


### PR DESCRIPTION
Added fallbackFocus option as proposed in #18.

Left description in README empty so that you can propose what to write there.

(Also fixed unneeded space before `returnFocusOnDeactivate` option)