### PR TITLE
Don't (re)focus and select if focus is already in the target element during trap activation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,7 +11,7 @@
 
 </head>
 <body>
-  <h1 tabindex="0">focus-trap demo</h1>
+  <h1 tabindex="0">focus-trap demo2</h1>
 
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
@@ -238,6 +238,30 @@
     <p>
       <button id="demo-seven-hide-focusable" style="display:none;">
         hide focusable button
+      </button>
+    </p>
+  </div>
+
+  <h2 id="demo-eight-heading">demo eight</h2>
+  <p>
+    When you write, trap is activating automatically, without changing selection.
+  </p>
+  <p>
+    Also, in this demo the Escape key does not deactivate the focus trap. You must click the button.
+  </p>
+  <div id="demo-eight" class="trap">
+    <p>
+      Here is a focus trap <a href="#">with</a> <a href="#">some</a> <a href="#">focusable</a> parts.
+    </p>
+    <p>
+      <label htmlFor="focused-input8" class="inline-label">
+        Initially focused input
+      </label>
+      <input id="focused-input8" />
+    </p>
+    <p>
+      <button id="deactivate-eight">
+        deactivate trap 8
       </button>
     </p>
   </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,7 +11,7 @@
 
 </head>
 <body>
-  <h1 tabindex="0">focus-trap demo2</h1>
+  <h1 tabindex="0">focus-trap demo</h1>
 
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>

--- a/demo/js/demo-eight.js
+++ b/demo/js/demo-eight.js
@@ -1,0 +1,22 @@
+var createFocusTrap = require('../../');
+
+var containerEight = document.getElementById('demo-eight');
+
+var focusTrapEight = createFocusTrap(containerEight, {
+  onActivate: function () {
+    containerEight.className = 'trap is-active';
+  },
+  onDeactivate: function () {
+    containerEight.className = 'trap';
+  },
+  initialFocus: '#focused-input8',
+  escapeDeactivates: false,
+});
+
+document.getElementById('focused-input8').addEventListener('input', function () {
+  focusTrapEight.activate();
+});
+
+document.getElementById('deactivate-eight').addEventListener('click', function () {
+  focusTrapEight.deactivate();
+});

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -5,3 +5,4 @@ require('./demo-four');
 require('./demo-five');
 require('./demo-six');
 require('./demo-seven');
+require('./demo-eight');

--- a/index.js
+++ b/index.js
@@ -226,6 +226,8 @@ function isEscapeEvent(e) {
 
 function tryFocus(node) {
   if (!node || !node.focus) return;
+  if (node === document.activeElement)  return;
+
   node.focus();
   if (node.tagName.toLowerCase() === 'input') {
     node.select();


### PR DESCRIPTION
I have a focus trap for an input that is automatically activated when the user types something in that input.

During the activation the library is not checking if the node to focus is the same already focused, resulting in a misleading behavior: while user is inputing characters, the text become selected and continuing typing overwrites previously inserted chars. 

This PR just do this check in tryFocus() before focusing:

`
    if (node === document.activeElement)  return;
`