### PR TITLE
Preventing the Bubbling on outside-buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ function focusTrap(element, userOptions) {
   // so that it precedes the focus event
   function checkPointerDown(e) {
     if (config.clickOutsideDeactivates && !container.contains(e.target)) {
+      e.preventDefault();
       deactivate({ returnFocus: false });
     }
   }


### PR DESCRIPTION
I hit an issue where clicking outside of a trapped dialog *should* close the dialog however when I clicked outside on a button that had a touchend, it would re-trigger and flicker the dialog back.

Preventing the event cleaned up the issue.

Cheers
-Pete