### PR TITLE
Feature/tabindex-1

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -266,6 +266,45 @@
     </p>
   </div>
 
+  <h2 id="demo-nine-heading">demo nine</h2>
+  <p>
+    Initial focus on a element with a tabindex of -1 and no focus outline;
+    so when you "tab" you will get to the next or previous element according to the browser.
+    While tabbing through, the focus does not return to the initial focused element.
+  </p>
+  <p>
+    <button id="activate-nine">
+      activate trap 9
+    </button>
+  </p>
+  <div id="demo-nine" class="trap">
+    <p>
+      <button>
+        nothing
+      </button>
+    </p>
+    <p>
+      <button tabindex="1">
+        tabindex=1
+      </button>
+    </p>
+    <p>
+      <button>
+        nothing
+      </button>
+    </p>
+    <p>
+      <button id="initial-nine" tabindex="-1">
+        Initial (tabindex="-1")
+      </button>
+    </p>
+    <p>
+      <button id="deactivate-nine">
+        deactivate trap 9
+      </button>
+    </p>
+  </div>
+
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/davidtheclark/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/js/demo-nine.js
+++ b/demo/js/demo-nine.js
@@ -1,0 +1,23 @@
+var createFocusTrap = require('../../');
+
+var containerNine = document.getElementById('demo-nine');
+
+var focusTrapNine = createFocusTrap(containerNine, {
+  onActivate: function () {
+    containerNine.className = 'trap is-active';
+  },
+  onDeactivate: function () {
+    containerNine.className = 'trap';
+  },
+  initialFocus: function () {
+    return document.getElementById('initial-nine');
+  },
+});
+
+document.getElementById('activate-nine').addEventListener('click', function () {
+  focusTrapNine.activate();
+});
+
+document.getElementById('deactivate-nine').addEventListener('click', function () {
+  focusTrapNine.deactivate();
+});

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -6,3 +6,4 @@ require('./demo-five');
 require('./demo-six');
 require('./demo-seven');
 require('./demo-eight');
+require('./demo-nine');

--- a/demo/style.css
+++ b/demo/style.css
@@ -29,6 +29,7 @@ body {
   margin-right: 0.5em;
 }
 
-#demo-four {
+#demo-four,
+#initial-nine {
   outline: 0;
 }

--- a/index.js
+++ b/index.js
@@ -188,7 +188,6 @@ function focusTrap(element, userOptions) {
     
     if (tabEvent) {
       handleTab(tabEvent);
-      tabEvent = null;
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ function focusTrap(element, userOptions) {
   var tabbableNodes = [];
   var nodeFocusedBeforeActivation = null;
   var active = false;
-  var paused = false;
+  var paused = false;  
+  var tabEvent = null;
 
   var container = (typeof element === 'string')
     ? document.querySelector(element)
@@ -184,11 +185,16 @@ function focusTrap(element, userOptions) {
     e.stopImmediatePropagation();
     // Checking for a blur method here resolves a Firefox issue (#15)
     if (typeof e.target.blur === 'function') e.target.blur();
+    
+    if (tabEvent) {
+      handleTab(tabEvent);
+      tabEvent = null;
+    }
   }
 
   function checkKey(e) {
     if (e.key === 'Tab' || e.keyCode === 9) {
-      handleTab(e);
+      tabEvent = e;
     }
 
     if (config.escapeDeactivates !== false && isEscapeEvent(e)) {
@@ -197,22 +203,15 @@ function focusTrap(element, userOptions) {
   }
 
   function handleTab(e) {
-    e.preventDefault();
     updateTabbableNodes();
-    var currentFocusIndex = tabbableNodes.indexOf(e.target);
     var lastTabbableNode = tabbableNodes[tabbableNodes.length - 1];
     var firstTabbableNode = tabbableNodes[0];
 
     if (e.shiftKey) {
-      if (e.target === firstTabbableNode || tabbableNodes.indexOf(e.target) === -1) {
-        return tryFocus(lastTabbableNode);
-      }
-      return tryFocus(tabbableNodes[currentFocusIndex - 1]);
+      return tryFocus(lastTabbableNode);
     }
 
-    if (e.target === lastTabbableNode) return tryFocus(firstTabbableNode);
-
-    tryFocus(tabbableNodes[currentFocusIndex + 1]);
+    tryFocus(firstTabbableNode);
   }
 
   function updateTabbableNodes() {


### PR DESCRIPTION
Hi @davidtheclark :) 
I tried to make a minimum of changes to your code. I let the Browser handle the focus while tabbing. Afterwards `checkFocus()` checks if the focus left the trap and sets it back to the first or last tabbable element if necessary. Therefore I previously cache the tab-Event in a new object and read out if the user hit `Shift+Tab` or not. Depending on that information the focus will be set to the according element.
Tell me what you think about it. I'm open to suggested improvements.