### PR TITLE
isOutsideElementFocusable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Returns a new focus trap on `element`.
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
 - **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
+- **isOutsideElementFocusable** {function}: A function that returns if an element on the page should be part of the tab cycle. By default only descendant of the container are focusable. 
 
 ### focusTrap.activate([activateOptions])
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Returns a new focus trap on `element`.
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
 - **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
-- **isOutsideElementFocusable** {function}: A function that returns if an element on the page should be part of the tab cycle. By default only descendant of the container are focusable. 
+- **isOutsideElementClickable** {function}: A function that returns if an element on the page should be part of the tab cycle. By default only descendant of the container are focusable. 
 
 ### focusTrap.activate([activateOptions])
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -308,10 +308,10 @@
 
   <h2 id="demo-includenode-heading">demo include outside nodes</h2>
   <p>
-    Use <code>isOutsideElementFocusable</code> option to allow elements that are outside the container to be focusable
+    Use <code>isOutsideElementClickable</code> option to allow elements that are outside the container to be clickable
   </p>
   <p>
-    It is useful when the container contains components that have pieces not part of the same DOM hierarchy
+    It is useful when the container contains components that have pieces not part of the same DOM hierarchy.
   </p>
 
   <p>
@@ -320,7 +320,7 @@
     </button>
   </p>
 
-  <button class="included-element">Included Element</button>
+  <button class="included-element">Outside Element Clickable</button>
   <div id="demo-includenode-container" class="trap">
     <button>
       Btn 1
@@ -336,7 +336,7 @@
   </div>
 
   <div>
-  <button class="included-element">Included Element</button>
+  <button class="included-element">Outside Element Clickable</button>
   </div>
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>

--- a/demo/index.html
+++ b/demo/index.html
@@ -305,6 +305,39 @@
     </p>
   </div>
 
+
+  <h2 id="demo-includenode-heading">demo include outside nodes</h2>
+  <p>
+    Use <code>isOutsideElementFocusable</code> option to allow elements that are outside the container to be focusable
+  </p>
+  <p>
+    It is useful when the container contains components that have pieces not part of the same DOM hierarchy
+  </p>
+
+  <p>
+    <button id="demo-includenode-activate">
+      Activate
+    </button>
+  </p>
+
+  <button class="included-element">Included Element</button>
+  <div id="demo-includenode-container" class="trap">
+    <button>
+      Btn 1
+    </button>
+    <button>
+      Btn 2
+    </button>
+    <p>
+      <button id="demo-includenode-deactivate">
+        deactivate trap 9
+      </button>
+    </p>
+  </div>
+
+  <div>
+  <button class="included-element">Included Element</button>
+  </div>
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/davidtheclark/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/js/demo-includenodes.js
+++ b/demo/js/demo-includenodes.js
@@ -4,7 +4,7 @@ var containerExclude = document.getElementById('demo-includenode-container');
 var includedElements = document.querySelectorAll('.included-element');
 
 var focusTrapExclude = createFocusTrap(containerExclude, {
-  isOutsideElementFocusable: function (element) {
+  isOutsideElementClickable: function (element) {
     return Array.prototype.slice.call(includedElements).indexOf(element) !== -1;
   },
   onActivate: function () {

--- a/demo/js/demo-includenodes.js
+++ b/demo/js/demo-includenodes.js
@@ -1,0 +1,30 @@
+var createFocusTrap = require('../../');
+
+var containerExclude = document.getElementById('demo-includenode-container');
+var includedElements = document.querySelectorAll('.included-element');
+
+var focusTrapExclude = createFocusTrap(containerExclude, {
+  isOutsideElementFocusable: function (element) {
+    return Array.prototype.slice.call(includedElements).indexOf(element) !== -1;
+  },
+  onActivate: function () {
+    containerExclude.className = 'trap is-active';
+  },
+  onDeactivate: function () {
+    containerExclude.className = 'trap';
+  },
+});
+
+document.getElementById('demo-includenode-activate').addEventListener('click', function () {
+  focusTrapExclude.activate();
+});
+document.getElementById('demo-includenode-deactivate').addEventListener('click', function () {
+  focusTrapExclude.deactivate();
+});
+
+includedElements[0].addEventListener('click', logOutsideElement);
+includedElements[1].addEventListener('click', logOutsideElement);
+
+function logOutsideElement() {
+  console.log('clicked on outside element');
+}

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -7,3 +7,4 @@ require('./demo-six');
 require('./demo-seven');
 require('./demo-eight');
 require('./demo-nine');
+require('./demo-includenodes');

--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ function focusTrap(element, userOptions) {
   config.escapeDeactivates = (userOptions && userOptions.escapeDeactivates !== undefined)
     ? userOptions.escapeDeactivates
     : true;
+  config.isOutsideElementFocusable = (userOptions && userOptions.isOutsideElementFocusable !== undefined)
+      ? userOptions.isOutsideElementFocusable
+      : function () {
+        return false;
+      };
+  config.includedContainers = (userOptions && userOptions.includedContainers !== undefined)
+      ? userOptions.includedContainers
+      : [];
 
   var trap = {
     activate: activate,
@@ -176,13 +184,13 @@ function focusTrap(element, userOptions) {
 
   function checkClick(e) {
     if (config.clickOutsideDeactivates) return;
-    if (container.contains(e.target)) return;
+    if (isElementFocusable(e.target)) return;
     e.preventDefault();
     e.stopImmediatePropagation();
   }
 
   function checkFocus(e) {
-    if (container.contains(e.target)) return;
+    if (isElementFocusable(e.target)) return;
     e.preventDefault();
     e.stopImmediatePropagation();
     // Checking for a blur method here resolves a Firefox issue (#15)
@@ -191,6 +199,10 @@ function focusTrap(element, userOptions) {
     if (tabEvent) {
       readjustFocus(tabEvent);
     }
+  }
+
+  function isElementFocusable(element){
+    return container.contains(element) || config.isOutsideElementFocusable(element);
   }
 
   function checkKey(e) {
@@ -226,7 +238,8 @@ function focusTrap(element, userOptions) {
   }
 
   function updateTabbableNodes() {
-    tabbableNodes = tabbable(container);
+    var documentTabbableNodes = tabbable(document.querySelector('body'));
+    tabbableNodes = documentTabbableNodes.filter(isElementFocusable);
     firstTabbableNode = tabbableNodes[0];
     lastTabbableNode = tabbableNodes[tabbableNodes.length - 1];
   }

--- a/index.js
+++ b/index.js
@@ -22,14 +22,12 @@ function focusTrap(element, userOptions) {
   config.escapeDeactivates = (userOptions && userOptions.escapeDeactivates !== undefined)
     ? userOptions.escapeDeactivates
     : true;
-  config.isOutsideElementFocusable = (userOptions && userOptions.isOutsideElementFocusable !== undefined)
-      ? userOptions.isOutsideElementFocusable
-      : function () {
-        return false;
-      };
-  config.includedContainers = (userOptions && userOptions.includedContainers !== undefined)
-      ? userOptions.includedContainers
-      : [];
+
+  config.isOutsideElementClickable = (userOptions && userOptions.isOutsideElementClickable !== undefined)
+    ? userOptions.isOutsideElementClickable
+    : function () {
+      return false;
+    };
 
   var trap = {
     activate: activate,
@@ -184,13 +182,14 @@ function focusTrap(element, userOptions) {
 
   function checkClick(e) {
     if (config.clickOutsideDeactivates) return;
-    if (isElementFocusable(e.target)) return;
+    if (config.isOutsideElementClickable(e.target)) return;
+    if (container.contains(e.target)) return;
     e.preventDefault();
     e.stopImmediatePropagation();
   }
 
   function checkFocus(e) {
-    if (isElementFocusable(e.target)) return;
+    if (container.contains(e.target)) return;
     e.preventDefault();
     e.stopImmediatePropagation();
     // Checking for a blur method here resolves a Firefox issue (#15)
@@ -199,10 +198,6 @@ function focusTrap(element, userOptions) {
     if (tabEvent) {
       readjustFocus(tabEvent);
     }
-  }
-
-  function isElementFocusable(element){
-    return container.contains(element) || config.isOutsideElementFocusable(element);
   }
 
   function checkKey(e) {
@@ -238,8 +233,7 @@ function focusTrap(element, userOptions) {
   }
 
   function updateTabbableNodes() {
-    var documentTabbableNodes = tabbable(document.querySelector('body'));
-    tabbableNodes = documentTabbableNodes.filter(isElementFocusable);
+    tabbableNodes = tabbable(container);
     firstTabbableNode = tabbableNodes[0];
     lastTabbableNode = tabbableNodes[tabbableNodes.length - 1];
   }


### PR DESCRIPTION
Add `isOutsideElementFocusable` API to allow elements outside of the container to be part of the tab cycle and be focusable.

It should fix https://github.com/davidtheclark/focus-trap/issues/42
