### PR TITLE
Maintain a history of traps to restore focus to a previously active trap

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -171,6 +171,35 @@
     </div>
   </div>
 
+  <h2 id="sibling-heading">sibling traps</h2>
+  <p>
+    Sibling focus traps. When the second trap is deactivated, focus returns to the first trap.
+  </p>
+  <div id="sibling-first" class="trap" tabindex="-1">
+    <p>
+      <button id="activate-first-sibling">
+        activate first trap
+      </button>
+    </p>
+    <p>
+      <button id="deactivate-first-sibling">
+        deactivate first trap
+      </button>
+    </p>
+    <p>
+      <button id="activate-second-sibling">
+        activate second trap
+      </button>
+    </p>
+  </div>
+  <div id="sibling-second" class="trap" tabindex="-1" style="display: none;">
+    <p>
+      <button id="deactivate-second-sibling">
+        deactivate second trap
+      </button>
+    </p>
+  </div>
+
   <h2 id="tif-heading">tricky initial focus</h2>
   <p>
     In this focus trap, the single focusable button is hidden (the ones you see at first have <code>tabindex="-1"</code>).

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -3,6 +3,7 @@ require('./initial-element-no-escape');
 require('./initially-focused-container');
 require('./hidden-treasures');
 require('./nested');
+require('./sibling');
 require('./tricky-initial-focus');
 require('./input-activation');
 require('./delay');

--- a/demo/js/sibling.js
+++ b/demo/js/sibling.js
@@ -1,0 +1,38 @@
+var createFocusTrap = require('../../');
+
+var container = document.getElementById('sibling-first');
+var second = document.getElementById('sibling-second');
+
+var firstFocusTrap = createFocusTrap('#sibling-first');
+
+var secondFocusTrap = createFocusTrap('#sibling-second');
+
+document
+  .getElementById('activate-first-sibling')
+  .addEventListener('click', function() {
+    container.className = 'trap is-active';
+    firstFocusTrap.activate();
+  });
+
+document
+  .getElementById('deactivate-first-sibling')
+  .addEventListener('click', function() {
+    container.className = 'trap';
+    firstFocusTrap.deactivate();
+  });
+
+document
+  .getElementById('activate-second-sibling')
+  .addEventListener('click', function() {
+    second.style.display = 'block';
+    second.className = 'trap is-active';
+    secondFocusTrap.activate();
+  });
+
+document
+  .getElementById('deactivate-second-sibling')
+  .addEventListener('click', function() {
+    second.style.display = 'none';
+    second.className = 'trap';
+    secondFocusTrap.deactivate();
+  });


### PR DESCRIPTION
Feature changes as discussed in https://github.com/davidtheclark/focus-trap-react/pull/30. Converted  `listeningFocusTrap` to `activeFocusTraps` which manages a queue of active traps and interaction between them on [de]activation.

Also added a _sibling_ demo to demonstrate and test functionality.