### PR TITLE
Upgrade the version of tabbable to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6123,9 +6123,9 @@
       }
     },
     "tabbable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.0.tgz",
-      "integrity": "sha512-W+w8dbSbQiuhMQhJbgtSn7ksg1Z+Z0UQq0WpDuYUrXjqie2bkMTfXRhdKtyQ8lRbppDWFoQf+S3T+OBGxoEPUA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.1.tgz",
+      "integrity": "sha512-583MHIOwictf7+zbxqO/L5fBqMN6Li4SJ1XTKQA9WzHRA7c2BB+D+Ny7Y6kGqU2u+rHK59+oRzrBvMU53aZz+A=="
     },
     "table": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/davidtheclark/focus-trap#readme",
   "dependencies": {
-    "tabbable": "^3.1.0",
+    "tabbable": "^3.1.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This change allows `focus-trap` to be used in React components rendered on server side.

See [tabbable PR#33](https://github.com/davidtheclark/tabbable/pull/33)