### PR TITLE
Register listeners explicitly as not passive

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,10 +143,22 @@ function focusTrap(element, userOptions) {
       tryFocus(getInitialFocusNode());
     });
     doc.addEventListener('focusin', checkFocusIn, true);
-    doc.addEventListener('mousedown', checkPointerDown, true);
-    doc.addEventListener('touchstart', checkPointerDown, true);
-    doc.addEventListener('click', checkClick, true);
-    doc.addEventListener('keydown', checkKey, true);
+    doc.addEventListener('mousedown', checkPointerDown, {
+      capture: true,
+      passive: false
+    });
+    doc.addEventListener('touchstart', checkPointerDown, {
+      capture: true,
+      passive: false
+    });
+    doc.addEventListener('click', checkClick, {
+      capture: true,
+      passive: false
+    });
+    doc.addEventListener('keydown', checkKey, {
+      capture: true,
+      passive: false
+    });
 
     return trap;
   }


### PR DESCRIPTION
Listeners are preventing the default action in some conditions. Recent Chrome versions have an intervention registering root-level listeners as passive by default for some events. So listeners have to be declared as non-passive explicitly.