### PR TITLE
Add `allowOutsideClick` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.1
+
+- Add `allowOutsideClick` option that allows you to pass a click event through, even when `clickOutsideDeactivates` is `false`
+
 ## 5.0.0
 
 - Update Tabbable to improve performance (see [Tabbable's changelog](https://github.com/davidtheclark/tabbable/blob/master/CHANGELOG.md)).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Returns a new focus trap on `element`.
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
 - **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
+- **allowOutsideClick** {function}: If set and returns `true`, a click outside the focus trap will not be prevented, even when `clickOutsideDeactivates` is `false`.
 
 ### focusTrap.activate([activateOptions])
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -317,6 +317,26 @@
     </p>
   </div>
 
+  <h2 id="allowoutsideclick-heading">allowOutsideClick option</h2>
+  <p>
+    This focus trap can be closed also by clicking a button outside of the trap.
+  </p>
+  <p>
+    <button id="activate-allowoutsideclick">
+      activate trap
+    </button>
+  </p>
+  <div id="allowoutsideclick" class="trap">
+    <p>
+      Here is a focus trap <a href="#">with</a> <a href="#">some</a> <a href="#">focusable</a> parts.
+    </p>
+    <p>
+      <button id="deactivate-allowoutsideclick">
+        deactivate trap
+      </button>
+    </p>
+  </div>
+
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/davidtheclark/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/js/allowoutsideclick.js
+++ b/demo/js/allowoutsideclick.js
@@ -1,0 +1,45 @@
+var createFocusTrap = require('../../');
+
+var container = document.getElementById('allowoutsideclick');
+var trigger = document.getElementById('activate-allowoutsideclick');
+var active = false;
+
+var focusTrap = createFocusTrap('#allowoutsideclick', {
+  allowOutsideClick: function(event) {
+    if (event.target === trigger) {
+      return true;
+    }
+  },
+  onActivate: function() {
+    container.className = 'trap is-active';
+  },
+  onDeactivate: function() {
+    container.className = 'trap';
+  }
+});
+
+function activate() {
+  focusTrap.activate();
+  active = true;
+  trigger.innerText = 'deactivate trap';
+}
+
+function deactivate() {
+  focusTrap.deactivate();
+  active = false;
+  trigger.innerText = 'activate trap';
+}
+
+trigger.addEventListener('click', function() {
+  if (active) {
+    deactivate();
+  } else {
+    activate();
+  }
+});
+
+document
+  .getElementById('deactivate-allowoutsideclick')
+  .addEventListener('click', function() {
+    deactivate();
+  });

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -9,3 +9,4 @@ require('./input-activation');
 require('./delay');
 require('./radio');
 require('./iframe');
+require('./allowoutsideclick');

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,8 @@ declare module "focus-trap" {
      * deactivate the focus trap and allow the click event to do its thing.
      */
     clickOutsideDeactivates?: boolean;
+
+    allowOutsideClick?: (event: MouseEvent) => boolean;
   }
 
   type ActivateOptions = Pick<Options, "onActivate">;

--- a/index.js
+++ b/index.js
@@ -227,9 +227,15 @@ function focusTrap(element, userOptions) {
       deactivate({
         returnFocus: !tabbable.isFocusable(e.target)
       });
-    } else {
-      e.preventDefault();
+      return;
     }
+    // This is needed for mobile devices.
+    // (If we'll only let `click` events through,
+    // then on mobile they will be blocked anyways if `touchstart` is blocked.)
+    if (config.allowOutsideClick && config.allowOutsideClick(e)) {
+      return;
+    }
+    e.preventDefault();
   }
 
   // In case focus escapes the trap for some strange reason, pull it back in.
@@ -275,6 +281,9 @@ function focusTrap(element, userOptions) {
   function checkClick(e) {
     if (config.clickOutsideDeactivates) return;
     if (container.contains(e.target)) return;
+    if (config.allowOutsideClick && config.allowOutsideClick(e)) {
+      return;
+    }
     e.preventDefault();
     e.stopImmediatePropagation();
   }


### PR DESCRIPTION
Solves problems like https://github.com/davidtheclark/focus-trap/issues/87 .

Might also solve problems like https://github.com/davidtheclark/focus-trap/pull/70#issuecomment-481014584, if you want to prevent all the clicks but the clicks on a specific element, that is for example responsible for activating/deactivating the focus trap (i.e. a button that opens a dropdown).

Demo video: https://www.dropbox.com/s/ryso8l3u5s14c23/focus-trap-allowoutsideclick-demo.mov?dl=0