### PR TITLE
Add setReturnFocus after deactivation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Returns a new focus trap on `element`.
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
 - **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
+- **setReturnFocus** {element|string|function}: By default, focus trap on deactivation will return to the element that was focused before activation. With this option you can specify another element to programmatically receive focus after deactivation. Can be a DOM node, or a selector string (which will be passed to `document.querySelector()` to find the DOM node), or a function that returns a DOM node.
 - **allowOutsideClick** {function}: If set and returns `true`, a click outside the focus trap will not be prevented, even when `clickOutsideDeactivates` is `false`.
 
 ### focusTrap.activate([activateOptions])

--- a/demo/index.html
+++ b/demo/index.html
@@ -337,6 +337,28 @@
     </p>
   </div>
 
+  <h2 id="setReturnFocus-heading">setReturnFocus option</h2>
+  <p>
+    With setReturnFocus it is possible to overwrite the returnFocusElement.
+  </p>
+  <p>
+    <button id="activate-setreturnfocus">
+      activate trap
+    </button>
+    <button id="overwritten-element">Element to return</button>
+  </p>
+  <div id="setreturnfocus" class="trap">
+    <p>
+      Here is a focus trap <a href="#">with</a> <a href="#">some</a>
+      <a href="#">focusable</a> parts.
+    </p>
+    <p>
+      <button id="deactivate-setreturnfocus">
+        deactivate trap
+      </button>
+    </p>
+  </div>
+
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/davidtheclark/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -10,3 +10,4 @@ require('./delay');
 require('./radio');
 require('./iframe');
 require('./allowoutsideclick');
+require('./set-return-focus');

--- a/demo/js/set-return-focus.js
+++ b/demo/js/set-return-focus.js
@@ -1,0 +1,25 @@
+var createFocusTrap = require('../../');
+
+var container = document.getElementById('setreturnfocus');
+
+var focusTrap = createFocusTrap('#setreturnfocus', {
+  onActivate: function() {
+    container.className = 'trap is-active';
+  },
+  onDeactivate: function() {
+    container.className = 'trap';
+  },
+  setReturnFocus: '#overwritten-element'
+});
+
+document
+  .getElementById('activate-setreturnfocus')
+  .addEventListener('click', function() {
+    focusTrap.activate();
+  });
+
+document
+  .getElementById('deactivate-setreturnfocus')
+  .addEventListener('click', function() {
+    focusTrap.deactivate();
+  });

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,12 @@ declare module "focus-trap" {
     returnFocusOnDeactivate?: boolean;
 
     /**
+     * By default, focus trap on deactivation will return to the element
+     * that was focused before activation.
+    */
+    setReturnFocus?: FocusTarget;
+
+    /**
      * Default: `true`. If `false`, the `Escape` key will not trigger
      * deactivation of the focus trap. This can be useful if you want
      * to force the user to make a decision instead of allowing an easy

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function focusTrap(element, userOptions) {
 
     state.active = true;
     state.paused = false;
-    state.nodeFocusedBeforeActivation = getReturnFocusNode(doc.activeElement);
+    state.nodeFocusedBeforeActivation = doc.activeElement;
 
     var onActivate =
       activateOptions && activateOptions.onActivate
@@ -114,7 +114,7 @@ function focusTrap(element, userOptions) {
         : config.returnFocusOnDeactivate;
     if (returnFocus) {
       delay(function() {
-        tryFocus(state.nodeFocusedBeforeActivation);
+        tryFocus(getReturnFocusNode(state.nodeFocusedBeforeActivation));
       });
     }
 
@@ -221,18 +221,7 @@ function focusTrap(element, userOptions) {
 
   function getReturnFocusNode(previousActiveElement) {
     var node = getNodeForOption('setReturnFocus');
-
-    if (!node) {
-      node = previousActiveElement;
-    }
-
-    if (!node || !previousActiveElement) {
-      throw new Error(
-        'Your focus-trap needs to have at least one focusable element'
-      );
-    }
-
-    return node;
+    return node ? node : previousActiveElement;
   }
 
   // This needs to be done on mousedown and touchstart instead of click

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function focusTrap(element, userOptions) {
 
     state.active = true;
     state.paused = false;
-    state.nodeFocusedBeforeActivation = doc.activeElement;
+    state.nodeFocusedBeforeActivation = getReturnFocusNode(doc.activeElement);
 
     var onActivate =
       activateOptions && activateOptions.onActivate
@@ -219,6 +219,23 @@ function focusTrap(element, userOptions) {
     return node;
   }
 
+  function getReturnFocusNode(previousActiveElement) {
+    var node;
+    if (getNodeForOption('setReturnFocus') !== null) {
+      node = getNodeForOption('setReturnFocus');
+    } else {
+      node = previousActiveElement;
+    }
+
+    if (!node) {
+      throw new Error(
+        "You can't have a focus-trap without at least one focusable element"
+      );
+    }
+
+    return node;
+  }
+
   // This needs to be done on mousedown and touchstart instead of click
   // so that it precedes the focus event.
   function checkPointerDown(e) {
@@ -301,7 +318,6 @@ function focusTrap(element, userOptions) {
       tryFocus(getInitialFocusNode());
       return;
     }
-
     node.focus();
     state.mostRecentlyFocusedNode = node;
     if (isSelectableInput(node)) {

--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ function focusTrap(element, userOptions) {
 
     if (!node) {
       throw new Error(
-        "You can't have a focus-trap without at least one focusable element"
+        'Your focus-trap needs to have at least one focusable element'
       );
     }
 
@@ -220,16 +220,15 @@ function focusTrap(element, userOptions) {
   }
 
   function getReturnFocusNode(previousActiveElement) {
-    var node;
-    if (getNodeForOption('setReturnFocus') !== null) {
-      node = getNodeForOption('setReturnFocus');
-    } else {
+    var node = getNodeForOption('setReturnFocus');
+
+    if (!node) {
       node = previousActiveElement;
     }
 
-    if (!node) {
+    if (!node || !previousActiveElement) {
       throw new Error(
-        "You can't have a focus-trap without at least one focusable element"
+        'Your focus-trap needs to have at least one focusable element'
       );
     }
 


### PR DESCRIPTION
This option is useful when it is needed to set the returning element after deactivation programmatically.

In my case, another 3rd party library for modals sets the focus on the modal container. As I'm using the focus trap on modal, then the modal container focusing is called before focus trap sets the `state.nodeFocusedBeforeActivation`, which means after closing the modal focus trap won't return to previously focused element.

With this option I can manually set where it should return.