### PR TITLE
feat: Add option for preventing scroll

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ function focusTrap(element, userOptions) {
       tryFocus(getInitialFocusNode());
       return;
     }
-    node.focus();
+    node.focus({preventScroll: userOptions.preventScroll});
     state.mostRecentlyFocusedNode = node;
     if (isSelectableInput(node)) {
       node.select();


### PR DESCRIPTION
As noted in [this issue](https://github.com/davidtheclark/focus-trap/issues/104), I've been encountering a bug in IE where element focus causes the screen to scroll.

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus), there is an optional parameter you can pass in that defaults to `{preventScroll: false}`.

I propose we add the ability to pass down `preventScroll` from userOptions in order to grant flexibility for whether or not devs want the focus to trigger page scroll. On line 309, I added `{preventScroll: userOptions.preventScroll}`.